### PR TITLE
feat(workflow): disable weekly research schedule

### DIFF
--- a/.github/workflows/weekly-research.md
+++ b/.github/workflows/weekly-research.md
@@ -1,8 +1,5 @@
 ---
 on:
-  schedule:
-    # Every week, 9AM UTC, Monday
-    - cron: "0 9 * * 1"
   workflow_dispatch:
 
   stop-after: +30d # workflow will no longer trigger after 30 days. Remove this and recompile to run indefinitely


### PR DESCRIPTION
## 概要

週次研究ワークフローの自動実行を無効にしました。

## 変更内容

-  から  セクションを削除
- 毎週月曜日 9AM UTC の自動実行を停止
-  は維持し、手動実行は引き続き可能

## 理由

定期実行が不要になったため、手動実行のみに変更しました。

## テスト

- [x] ワークフローファイルの構文が正しいことを確認
- [x] 手動実行のトリガーが残っていることを確認

## 影響

- 自動実行されなくなります
- 手動実行は引き続き可能です