### PR TITLE
fix(workflow): restrict update docs trigger

### DIFF
--- a/.github/workflows/update-docs.lock.yml
+++ b/.github/workflows/update-docs.lock.yml
@@ -3,101 +3,21 @@
 #   gh aw compile
 # For more information: https://github.com/githubnext/gh-aw/blob/main/.github/instructions/github-agentic-workflows.instructions.md
 #
-# Effective stop-time: 2025-10-23 09:50:58
+# Effective stop-time: 2025-10-28 06:35:33
 
 name: "Update Docs Japanese"
 "on":
-  push:
-    branches:
-    - main
   workflow_dispatch: null
 
 permissions: {}
 
 concurrency:
-  group: "gh-aw-${{ github.workflow }}-${{ github.ref }}"
+  group: "gh-aw-${{ github.workflow }}"
 
 run-name: "Update Docs Japanese"
 
 jobs:
-  task:
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write  # Required for github.rest.actions.cancelWorkflowRun()
-    steps:
-      - name: Check team membership for workflow
-        id: check-team-member
-        uses: actions/github-script@v8
-        env:
-          GITHUB_AW_REQUIRED_ROLES: admin,maintainer
-        with:
-          script: |
-            async function setCancelled(message) {
-              try {
-                await github.rest.actions.cancelWorkflowRun({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  run_id: context.runId,
-                });
-                core.info(`Cancellation requested for this workflow run: ${message}`);
-              } catch (error) {
-                const errorMessage = error instanceof Error ? error.message : String(error);
-                core.warning(`Failed to cancel workflow run: ${errorMessage}`);
-                core.setFailed(message); // Fallback if API call fails
-              }
-            }
-            async function main() {
-              const { eventName } = context;
-              // skip check for safe events
-              const safeEvents = ["workflow_dispatch", "workflow_run", "schedule"];
-              if (safeEvents.includes(eventName)) {
-                core.info(`✅ Event ${eventName} does not require validation`);
-                return;
-              }
-              const actor = context.actor;
-              const { owner, repo } = context.repo;
-              const requiredPermissionsEnv = process.env.GITHUB_AW_REQUIRED_ROLES;
-              const requiredPermissions = requiredPermissionsEnv ? requiredPermissionsEnv.split(",").filter(p => p.trim() !== "") : [];
-              if (!requiredPermissions || requiredPermissions.length === 0) {
-                core.error("❌ Configuration error: Required permissions not specified. Contact repository administrator.");
-                await setCancelled("Configuration error: Required permissions not specified");
-                return;
-              }
-              // Check if the actor has the required repository permissions
-              try {
-                core.debug(`Checking if user '${actor}' has required permissions for ${owner}/${repo}`);
-                core.debug(`Required permissions: ${requiredPermissions.join(", ")}`);
-                const repoPermission = await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner: owner,
-                  repo: repo,
-                  username: actor,
-                });
-                const permission = repoPermission.data.permission;
-                core.debug(`Repository permission level: ${permission}`);
-                // Check if user has one of the required permission levels
-                for (const requiredPerm of requiredPermissions) {
-                  if (permission === requiredPerm || (requiredPerm === "maintainer" && permission === "maintain")) {
-                    core.info(`✅ User has ${permission} access to repository`);
-                    return;
-                  }
-                }
-                core.warning(`User permission '${permission}' does not meet requirements: ${requiredPermissions.join(", ")}`);
-              } catch (repoError) {
-                const errorMessage = repoError instanceof Error ? repoError.message : String(repoError);
-                core.warning(`Repository permission check failed: ${errorMessage}`);
-                await setCancelled(`Repository permission check failed: ${errorMessage}`);
-                return;
-              }
-              // Cancel the workflow when permission check fails
-              core.warning(
-                `Access denied: Only authorized users can trigger this workflow. User '${actor}' is not authorized. Required permissions: ${requiredPermissions.join(", ")}`
-              );
-              await setCancelled(`Access denied: User '${actor}' is not authorized. Required permissions: ${requiredPermissions.join(", ")}`);
-            }
-            await main();
-
   update-docs-japanese:
-    needs: task
     runs-on: ubuntu-latest
     permissions: read-all
     outputs:
@@ -676,7 +596,7 @@ jobs:
           WORKFLOW_NAME="Update Docs Japanese"
           
           # Check stop-time limit
-          STOP_TIME="2025-10-23 09:50:58"
+          STOP_TIME="2025-10-28 06:35:33"
           echo "Checking stop-time limit: $STOP_TIME"
           
           # Convert stop time to epoch seconds

--- a/.github/workflows/update-docs.md
+++ b/.github/workflows/update-docs.md
@@ -1,7 +1,5 @@
 ---
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
   stop-after: +30d # workflow will no longer trigger after 30 days. Remove this and recompile to run indefinitely
 
@@ -131,4 +129,3 @@ timeout_minutes: 15
 
 <!-- You can customize prompting and tools in .github/workflows/agentics/update-docs.config -->
 @include? agentics/update-docs.config
-


### PR DESCRIPTION
## Summary
- limit the Update Docs Agentics workflow to manual dispatch
- regenerate the compiled workflow definition via gh aw compile

## Testing
- gh aw compile