### PR TITLE
Fix(Vite): Nginxがデフォルトページを表示する問題を修正

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ const isStaticSubPath = process.env.NODE_ENV === 'production' && !isVercel;
 
 export default defineConfig({
   plugins: [react()],
-  base: isStaticSubPath ? '/sushida-clone/' : '/',
+  base: '/',
   server: {
     host: true,
   },


### PR DESCRIPTION
### 概要
デプロイされたアプリケーションにアクセスすると、Nginxのデフォルトページが表示される問題を修正します。

### 原因
 の  設定が、本番ビルド時に  になっていました。
これにより、生成された  が参照するアセットのパスが不正になり、リソースを読み込めていませんでした。

### 修正内容
-  の  を常に  になるよう修正。

### 確認事項
- このPRをマージすると、修正が反映されたアプリケーションの自動デプロイが開始されます。