### PR TITLE
Fix(Nginx): SPA用のルーティング設定を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ FROM nginx:1.25-alpine
 # Nginxがコンテンツを配信するデフォルトのディレクトリにコピーします
 COPY --from=builder /app/dist /usr/share/nginx/html
 
+# SPA用のNginx設定ファイルをコピー
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
 # コンテナが80番ポートを公開することを指定
 EXPOSE 80
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,14 @@
+server {
+  listen 80;
+  server_name localhost;
+
+  # ドキュメントルートを、Dockerfileでファイルをコピーした先に設定
+  root /usr/share/nginx/html;
+  index index.html index.htm;
+
+  location / {
+    # リクエストされたURIにファイルがあればそれを返す
+    # なければ、index.htmlを代わりに返す
+    try_files $uri $uri/ /index.html;
+  }
+}


### PR DESCRIPTION
### 概要
デプロイされたアプリケーションにアクセスすると、Nginxのデフォルトページが表示される、または/aboutなどのサブパスでリロードすると404になる問題を修正します。

### 原因
Nginxのデフォルト設定では、React Routerのようなクライアントサイドのルーティングに対応できません。
存在しないパスへのリクエストをにフォールバックさせる必要がありました。

### 修正内容
- SPA用のを追加 (ディレクティブを使用)
- を修正し、カスタムのをコンテナにコピーするように変更

### 確認事項
- このPRをマージすると、修正が反映されたアプリケーションの自動デプロイが開始されます。